### PR TITLE
Remove source code from auto export

### DIFF
--- a/auto-export/dockerfile
+++ b/auto-export/dockerfile
@@ -1,11 +1,12 @@
 FROM alpine:latest
 
-# Variables
+# Environment Variables
 ENV GODOT_VERSION "3.2.3"
+ENV GODOT_EXPORT_PRESET="Linux/X11"
 ENV GODOT_GAME_NAME ""
 ENV HTTPS_GIT_REPO ""
 
-# Updates and installs
+# Updates and installs to the server
 RUN apk update
 RUN apk add --no-cache bash
 RUN apk add --no-cache wget
@@ -27,9 +28,17 @@ RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${G
     && mv templates/* ~/.local/share/godot/templates/${GODOT_VERSION}.stable \
     && rm -f Godot_v${GODOT_VERSION}-stable_export_templates.tpz Godot_v${GODOT_VERSION}-stable_linux_headless.64.zip
 
-# Make directory to run the app from
+# Make needed directories for container
 RUN mkdir /godotapp
-WORKDIR /godotapp
+RUN mkdir /godotbuildspace
+
+# Move to the build space and export the .pck
+WORKDIR /godotbuildspace
 RUN git clone ${HTTPS_GIT_REPO} .
-RUN godot --path . --export-pack "Linux/X11" ${GODOT_GAME_NAME}.pck
+RUN godot --path /godotbuildspace --export-pack ${GODOT_EXPORT_PRESET} ${GODOT_GAME_NAME}.pck
+RUN mv ${GODOT_GAME_NAME}.pck /godotapp/
+
+# Change to the godotapp space, delete the source,  and run the app
+WORKDIR /godotapp
+run rm -f -R /godotbuildspace
 CMD godot --main-pack ${GODOT_GAME_NAME}.pck

--- a/manual-export/dockerfile
+++ b/manual-export/dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:latest
 
-# Variables
-ENV GODOT_VERSION "3.2.3"
-ENV GODOT_GAME_NAME ""
+# Environment Variables
+ENV GODOT_VERSION "3.2.3" # Version of Godot to download
+ENV GODOT_GAME_NAME "" # Name of the PCK file you want to run on the server
 ENV HTTPS_GIT_REPO ""
 
 # Updates and installs
@@ -15,7 +15,7 @@ RUN apk add --no-cache git
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk
 RUN apk add --allow-untrusted glibc-2.31-r0.apk
 
-# Download Godot, version is set from variables
+# Download Godot, version is set from environment variables
 RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${GODOT_VERSION}-stable_linux_server.64.zip \
     && mkdir ~/.cache \
     && mkdir -p ~/.config/godot \
@@ -23,7 +23,7 @@ RUN wget https://downloads.tuxfamily.org/godotengine/${GODOT_VERSION}/Godot_v${G
     && mv Godot_v${GODOT_VERSION}-stable_linux_server.64 /usr/local/bin/godot \
     && rm -f Godot_v${GODOT_VERSION}-stable_linux_server.64.zip
 
-# Make directory to run the app from
+# Make directory to run the app from and then run the app
 RUN mkdir /godotapp
 WORKDIR /godotapp
 RUN git clone ${HTTPS_GIT_REPO} .


### PR DESCRIPTION
This PR is in response to issue #3 where the source code would continue to live in the container after the auto export. The goal was to remove this for the end user to save on space